### PR TITLE
Make changes to be able to build in Ubuntu 14.04

### DIFF
--- a/bin/assemble.sh
+++ b/bin/assemble.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DIR=$( cd "$( dirname "$0" )" && pwd )
 GET=`which wget`
@@ -8,7 +8,7 @@ fi
 
 function download {
 	if [ ! -f "$DIR/$1" ]; then
-		( cd "$DIR" && $GET "http://closure-library.googlecode.com/git/closure/bin/build/$1" )
+		( cd "$DIR" && $GET "https://raw.githubusercontent.com/google/closure-library/master/closure/bin/build/$1" )
 	fi
 }
 

--- a/shim/classes.js
+++ b/shim/classes.js
@@ -1,7 +1,7 @@
 /*
 	This file is part of LocalRoute.js.
 
-	Written in 2012, 2013 by Juha Järvi
+	Written in 2012, 2013 by Juha JÃ¤rvi
 
 	To the extent possible under law, the author(s) have dedicated all          
 	copyright and related and neighboring rights to this software to the


### PR DESCRIPTION
Ubuntu 14.04 links /bin/sh to dash that caused problems. Also, location of the closure library has changed. Third, there was an encoding problem with the ä character in the classes.js file.
